### PR TITLE
Fix relative path of images

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,7 +471,7 @@ paper is in a portrait (display is taller than it is wider) orientation.
       <figure id="oa-embedded-certificate">
         <img
           style="width: 100%"
-          src="/images/oa-embedded-certificate.png"
+          src="images/oa-embedded-certificate.png"
           alt="Certificate Template"
         />
         <figcaption>Certificate Template</figcaption>
@@ -479,7 +479,7 @@ paper is in a portrait (display is taller than it is wider) orientation.
       <figure id="oa-embedded-transcript">
         <img
           style="width: 100%"
-          src="/images/oa-embedded-transcript.png"
+          src="images/oa-embedded-transcript.png"
           alt="Transcript Template"
         />
         <figcaption>Transcript Template</figcaption>
@@ -524,7 +524,7 @@ paper is in a portrait (display is taller than it is wider) orientation.
             <figure id="oa-embedded-sequence-diagram">
                 <img
                         style="width: 100%"
-                        src="/images/oa-embedded-sequence-diagram.png"
+                        src="images/oa-embedded-sequence-diagram.png"
                         alt="Sequence Diagram"
                 />
                 <figcaption>Sequence Diagram</figcaption>


### PR DESCRIPTION
## Context
The initial PR #13 included images. However, images are not resolving due to the use of absolute paths.

## What this PR does
Remove leading `/` to ensure image path is a relative one.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Open-Attestation/vc-render-method/pull/14.html" title="Last updated on Jun 19, 2024, 3:39 AM UTC (b1dc27e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c-ccg/vc-render-method/14/0a55cb9...Open-Attestation:b1dc27e.html" title="Last updated on Jun 19, 2024, 3:39 AM UTC (b1dc27e)">Diff</a>