### PR TITLE
Fix left-over `render` property to be `renderMethod`

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@ definition.
 
         <p>
 When an [=issuer=] desires to specify template-based rendering instructions
-for a [=verifiable credential=], they MAY add a `render` property that uses
+for a [=verifiable credential=], they MAY add a `renderMethod` property that uses
 the data model described below.
         </p>
 


### PR DESCRIPTION
It looks like a reference to the old `render` property remained - just updates to `renderMethod`.

While reading through the spec, I noticed that the [Algorithms section](https://w3c-ccg.github.io/vc-render-method/#render-templaterendermethod) is also still showing its history (it is specifically about the older SVGRenderMethod), but that may require more understanding. I'm happy to have a go if you think it's straight forward and prefer.